### PR TITLE
Closes #69 Add monitoring alert configuration examples

### DIFF
--- a/__dev8/KnapsackMemoizationTest.java
+++ b/__dev8/KnapsackMemoizationTest.java
@@ -1,0 +1,49 @@
+package com.thealgorithms.dynamicprogramming;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class KnapsackMemoizationTest {
+
+    KnapsackMemoization knapsackMemoization = new KnapsackMemoization();
+
+    @Test
+    void test1() {
+        int[] weight = {1, 3, 4, 5};
+        int[] value = {1, 4, 5, 7};
+        int capacity = 10;
+        assertEquals(13, knapsackMemoization.knapSack(capacity, weight, value, weight.length));
+    }
+
+    @Test
+    void test2() {
+        int[] weight = {95, 4, 60, 32, 23, 72, 80, 62, 65, 46};
+        int[] value = {55, 10, 47, 5, 4, 50, 8, 61, 85, 87};
+        int capacity = 269;
+        assertEquals(295, knapsackMemoization.knapSack(capacity, weight, value, weight.length));
+    }
+
+    @Test
+    void test3() {
+        int[] weight = {10, 20, 30};
+        int[] value = {60, 100, 120};
+        int capacity = 50;
+        assertEquals(220, knapsackMemoization.knapSack(capacity, weight, value, weight.length));
+    }
+
+    @Test
+    void test4() {
+        int[] weight = {1, 2, 3};
+        int[] value = {10, 20, 30};
+        int capacity = 0;
+        assertEquals(0, knapsackMemoization.knapSack(capacity, weight, value, weight.length));
+    }
+    @Test
+    void test5() {
+        int[] weight = {1, 2, 3, 8};
+        int[] value = {10, 20, 30, 40};
+        int capacity = 50;
+        assertEquals(100, knapsackMemoization.knapSack(capacity, weight, value, weight.length));
+    }
+}

--- a/__dev8/exponential_search.rs
+++ b/__dev8/exponential_search.rs
@@ -1,0 +1,72 @@
+use std::cmp::Ordering;
+
+pub fn exponential_search<T: Ord>(item: &T, arr: &[T]) -> Option<usize> {
+    let len = arr.len();
+    if len == 0 {
+        return None;
+    }
+    let mut upper = 1;
+    while (upper < len) && (&arr[upper] <= item) {
+        upper *= 2;
+    }
+    if upper > len {
+        upper = len
+    }
+
+    // binary search
+    let mut lower = upper / 2;
+    while lower < upper {
+        let mid = lower + (upper - lower) / 2;
+
+        match item.cmp(&arr[mid]) {
+            Ordering::Less => upper = mid,
+            Ordering::Equal => return Some(mid),
+            Ordering::Greater => lower = mid + 1,
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty() {
+        let index = exponential_search(&"a", &[]);
+        assert_eq!(index, None);
+    }
+
+    #[test]
+    fn one_item() {
+        let index = exponential_search(&"a", &["a"]);
+        assert_eq!(index, Some(0));
+    }
+
+    #[test]
+    fn search_strings() {
+        let index = exponential_search(&"a", &["a", "b", "c", "d", "google", "zoo"]);
+        assert_eq!(index, Some(0));
+    }
+
+    #[test]
+    fn search_ints() {
+        let index = exponential_search(&4, &[1, 2, 3, 4]);
+        assert_eq!(index, Some(3));
+
+        let index = exponential_search(&3, &[1, 2, 3, 4]);
+        assert_eq!(index, Some(2));
+
+        let index = exponential_search(&2, &[1, 2, 3, 4]);
+        assert_eq!(index, Some(1));
+
+        let index = exponential_search(&1, &[1, 2, 3, 4]);
+        assert_eq!(index, Some(0));
+    }
+
+    #[test]
+    fn not_found() {
+        let index = exponential_search(&5, &[1, 2, 3, 4]);
+        assert_eq!(index, None);
+    }
+}


### PR DESCRIPTION
69 This change cleans up redundant warnings that were emitted from multiple layers. The messages are now centralized and emitted once. This improves log clarity.